### PR TITLE
Adds a Makevars.win that works on windows.

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,0 +1,13 @@
+LIBDIR = myrustlib/target/release
+STATLIB = $(LIBDIR)/myrustlib.lib
+PKG_LIBS = -L$(LIBDIR) -lmyrustlib -lws2_32 -ladvapi32 -luserenv
+
+all: clean
+
+$(SHLIB): $(STATLIB)
+
+$(STATLIB):
+	cargo build --release --manifest-path=myrustlib/Cargo.toml
+
+clean:
+	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS) myrustlib/target


### PR DESCRIPTION
 Note that the default-host for rustup must be set to x86_64-pc-windows-gnu. Also these flags are necessary: -lws2_32 -ladvapi32 -luserenv